### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "reactjs"
+run = "yarn start"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/sdkayy/tryprospect)](https://repl.it/github/sdkayy/tryprospect)
+
 Hi - thank you for applying to Prospect! And thank you for doing this test.
 
 We'd like to keep this simple. The tasks below should ideally not take you more than 30 minutes. 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@sdkayy/tryprospect).